### PR TITLE
Replace ADS1115 library

### DIFF
--- a/include/PoolMaster.h
+++ b/include/PoolMaster.h
@@ -27,7 +27,7 @@
 #include <ESPmDNS.h>              // mDNS
 #include <ArduinoOTA.h>           // On The Air WiFi update 
 #include "AsyncMqttClient.h"      // Async. MQTT client
-#include "ADS1115.h"              // ADS1115 sensors library
+#include <Adafruit_ADS1X15.h>     // ADS1115 sensors library
 
 // General shared data structure
 struct StoreStruct
@@ -71,7 +71,7 @@ extern String Firmw;
 extern AsyncMqttClient mqttClient;                     // MQTT async. client
 
 // Various flags
-extern volatile bool startTasks;                                // flag to start loop tasks       
+extern volatile bool startTasks;                       // flag to start loop tasks       
 extern bool MQTTConnection;                            // MQTT connected flag
 extern bool EmergencyStopFiltPump;                     // Filtering pump stopped manually; needs to be cleared to restart
 extern bool AntiFreezeFiltering;                       // Filtration anti freeze mode

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,6 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 
 lib_ldf_mode = chain+
-lib_extra_dirs = D:\Documents\Electronique - Logiciels\PlatformIO\libraries
 build_flags = -D ESP32_DEVKITV1
 
 debug_tool = esp-prog
@@ -33,7 +32,7 @@ lib_deps =
 	Arduino_DebugUtils @ 1.1.0
 	paulstoffregen/Time @ 1.6
 	br3ttb/PID @ 1.2.1
-	ADS1115 @ 1.0.0
+	adafruit/Adafruit ADS1X15@^2.4.0
 	256dpi/MQTT @ ^2.4.8
 	robtillaart/RunningMedian @ ^0.2.1
 	bblanchon/ArduinoJson @ ^6.17.2
@@ -41,6 +40,7 @@ lib_deps =
 	milesburton/DallasTemperature @ ^3.9.1
 	me-no-dev/AsyncTCP @ ^1.1.1
 	marvinroger/AsyncMqttClient @ ^0.8.2
+	SPI
 
 ; UPLOAD via serial port
 [env:serial_upload]


### PR DESCRIPTION
Replace custom ADS1115 library by standard Adafruit one. Avoiding to have personal path in the configuration project.